### PR TITLE
Fix JSON payload format

### DIFF
--- a/safari_Push.php
+++ b/safari_Push.php
@@ -71,8 +71,8 @@ if ( !$error ) {
           'body' => $message,
           'action' => $action,
         ),
+        'url-args' => array($url_arg),
       ),
-      'url-args' => array($url_arg),
     );
 
     // Encode the payload as JSON


### PR DESCRIPTION
According to Listing 2.4 in  https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/NotificationProgrammingGuideForWebsites/PushNotifications/PushNotifications.html this is the correct format for the JSON payload.

Without this fix the script will return `Message successfully delivered`, but the notification won't be displayed, and this error will be logged:
`Failed to parse remote notification payload: payload must contain a "url-args" array inside the "aps" dictionary`